### PR TITLE
add another CMD layer to exec the container for non-manual deploys

### DIFF
--- a/dockerfiles/Dockerfile.cpu
+++ b/dockerfiles/Dockerfile.cpu
@@ -2,6 +2,7 @@
 
 FROM ubuntu:16.04
 
+
 # TensorBoard-related packages versions
 ARG TENSORBOARD_VERSION=1.5.0
 ARG TENSORFLOW_VERSION=1.5.0
@@ -42,3 +43,8 @@ RUN mkdir -p /root/cakechat/data/tensorboard
 WORKDIR /root/cakechat
 CMD (tensorboard --logdir=data/tensorboard 2>data/tensorboard/err.log &); \
     /bin/bash
+
+# Deployment CMD for container platforms
+# See: https://github.com/lukalabs/cakechat/issues/8
+
+CMD ["/bin/bash", "-c", "python", "bin/cakechat_server.py"]


### PR DESCRIPTION
Fixes #8 for intention to make it work on Orchestration platforms like Kubernetes or OpenShift.