### PR TITLE
Cakechat refactoring

### DIFF
--- a/cakechat/config.py
+++ b/cakechat/config.py
@@ -1,9 +1,9 @@
 import os
 
-from cakechat.utils.env import is_dev_env
 from cakechat.utils.data_structures import create_namedtuple_instance
+from cakechat.utils.env import is_dev_env
 
-RANDOM_SEED = 42  # Fix the random seed to a certain value to make everything reproducable
+RANDOM_SEED = 42  # Fix the random seed to a certain value to make everything reproducible
 
 # AWS S3 params
 S3_MODELS_BUCKET_NAME = 'cake-chat-data'  # S3 bucket with all the data
@@ -15,6 +15,7 @@ S3_W2V_REMOTE_DIR = 'w2v_models'  # S3 remote directory with pre-trained w2v mod
 # data params
 DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')  # Directory to store all the data
 # e.g. datasets, models, indices
+NN_MODELS_DIR = os.path.join(DATA_DIR, 'nn_models')
 PROCESSED_CORPUS_DIR = os.path.join(DATA_DIR, 'corpora_processed')  # Path to a processed corpora datasets
 TOKEN_INDEX_DIR = os.path.join(DATA_DIR, 'tokens_index')  # Path to a prepared tokens index file
 CONDITION_IDS_INDEX_DIR = os.path.join(DATA_DIR, 'conditions_index')  # Path to a prepared conditions index file
@@ -24,12 +25,13 @@ BASE_CORPUS_NAME = 'processed_dialogs'  # Basic corpus name prefix
 TRAIN_CORPUS_NAME = 'train_' + BASE_CORPUS_NAME  # Corpus name prefix for the training dataset
 CONTEXT_SENSITIVE_VAL_CORPUS_NAME = 'val_' + BASE_CORPUS_NAME  # Corpus name prefix for the validation dataset
 
-VAL_SUBSET_SIZE = 250  # Subset from the validation dataset to be used in validation metrics calculation
+MAX_VAL_LINES_NUM = 10000  # Max lines number from validation set to be used for metrics calculation
+VAL_SUBSET_SIZE = 250  # Subset from the validation dataset to be used to calculated some validation metrics
 TRAIN_SUBSET_SIZE = int(os.environ['SLICE_TRAINSET']) if 'SLICE_TRAINSET' in os.environ else None  # Subset from the
 # training dataset to be used during the training. In case of None use all lines in the train dataset (default behavior)
 
 # test data paths
-TEST_DATA_DIR = os.path.join(DATA_DIR, 'quality')  # Path to datasets for quality metrics calculation
+TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'quality')
 CONTEXT_FREE_VAL_CORPUS_NAME = 'context_free_validation_set'  # Context-free validation set path
 TEST_CORPUS_NAME = 'context_free_test_set'  # Context-free test set path
 QUESTIONS_CORPUS_NAME = 'context_free_questions'  # Context-free questions only path
@@ -61,9 +63,12 @@ INPUT_CONTEXT_SIZE = 3  # Maximum depth of the conversational history to be used
 OUTPUT_SEQUENCE_LENGTH = 32  # Output sequence length. Better to keep as INPUT_SEQUENCE_LENGTH+2 for start/end tokens
 BATCH_SIZE = 192  # Default batch size which fits into 8GB of GPU memory
 SHUFFLE_TRAINING_BATCHES = True  # Shuffle training batches in the dataset each epoch
-EPOCHES_NUM = 100  # Total epochs num
+EPOCHS_NUM = 100  # Total epochs num
 GRAD_CLIP = 5.0  # Gradient clipping passed into theano.gradient.grad_clip()
-ADADELTA_LEARNING_RATE = 1.0  # Initial AdaDelta learning rate
+LEARNING_RATE = 1.0
+
+# model params
+NN_MODEL_PREFIX = 'cakechat'  # specify prefix to be prepended to model's name
 
 # predictions params
 MAX_PREDICTIONS_LENGTH = 40  # Max. number of tokens which can be generated on the prediction step
@@ -94,8 +99,10 @@ MMI_REVERSE_MODEL_SCORE_WEIGHT = 1.0  # Weight for MMI reranking reverse-model s
 LOG_CANDIDATES_NUM = 10  # Number of candidates to be printed to output during the logging
 SCREEN_LOG_NUM_TEST_LINES = 10  # Number of first test lines to use when logging outputs on screen
 SCREEN_LOG_FREQUENCY_PER_BATCHES = 500  # How many batches to train until next logging of output on screen
-LOG_FREQUENCY_PER_BATCHES = 2500  # How many batches to train until next logging of all the output into file
-LOG_LOSS_DECAY = 0.99  # Decay for the averaging the loss which is printed in logs
+LOG_TO_TB_FREQUENCY_PER_BATCHES = 500  # How many batches to train until next metrics computed for TensorBoard
+LOG_TO_FILE_FREQUENCY_PER_BATCHES = 2500  # How many batches to train until next logging of all the output into file
+SAVE_MODEL_FREQUENCY_PER_BATCHES = 2500  # How many batches to train until next logging of all the output into file
+AVG_LOSS_DECAY = 0.99  # Decay for the averaging the loss
 
 # Use reduced sizes for input/output sequences, hidden layers and datasets sizes for the 'Developer Mode'
 if is_dev_env():
@@ -105,10 +112,13 @@ if is_dev_env():
     BATCH_SIZE = 128
     HIDDEN_LAYER_DIMENSION = 7
     SCREEN_LOG_FREQUENCY_PER_BATCHES = 2
-    LOG_FREQUENCY_PER_BATCHES = 3
+    LOG_TO_TB_FREQUENCY_PER_BATCHES = 3
+    LOG_TO_FILE_FREQUENCY_PER_BATCHES = 4
+    SAVE_MODEL_FREQUENCY_PER_BATCHES = 4
     WORD_EMBEDDING_DIMENSION = 15
     SAMPLES_NUM_FOR_RERANKING = BEAM_SIZE = 5
     LOG_CANDIDATES_NUM = 3
     USE_PRETRAINED_W2V_EMBEDDINGS_LAYER = False
     VAL_SUBSET_SIZE = 100
+    MAX_VAL_LINES_NUM = 100
     TRAIN_SUBSET_SIZE = 10000

--- a/cakechat/config.py
+++ b/cakechat/config.py
@@ -68,7 +68,7 @@ GRAD_CLIP = 5.0  # Gradient clipping passed into theano.gradient.grad_clip()
 LEARNING_RATE = 1.0  # Learning rate for the chosen optimizer (currently using Adadelta, see model.py)
 
 # model params
-NN_MODEL_PREFIX = 'cakechat'  # specify prefix to be prepended to model's name
+NN_MODEL_PREFIX = 'cakechat'  # Specify prefix to be prepended to model's name
 
 # predictions params
 MAX_PREDICTIONS_LENGTH = 40  # Max. number of tokens which can be generated on the prediction step

--- a/cakechat/config.py
+++ b/cakechat/config.py
@@ -15,7 +15,7 @@ S3_W2V_REMOTE_DIR = 'w2v_models'  # S3 remote directory with pre-trained w2v mod
 # data params
 DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')  # Directory to store all the data
 # e.g. datasets, models, indices
-NN_MODELS_DIR = os.path.join(DATA_DIR, 'nn_models')
+NN_MODELS_DIR = os.path.join(DATA_DIR, 'nn_models')  # Path to a directory for saving and restoring dialog models
 PROCESSED_CORPUS_DIR = os.path.join(DATA_DIR, 'corpora_processed')  # Path to a processed corpora datasets
 TOKEN_INDEX_DIR = os.path.join(DATA_DIR, 'tokens_index')  # Path to a prepared tokens index file
 CONDITION_IDS_INDEX_DIR = os.path.join(DATA_DIR, 'conditions_index')  # Path to a prepared conditions index file
@@ -65,7 +65,7 @@ BATCH_SIZE = 192  # Default batch size which fits into 8GB of GPU memory
 SHUFFLE_TRAINING_BATCHES = True  # Shuffle training batches in the dataset each epoch
 EPOCHS_NUM = 100  # Total epochs num
 GRAD_CLIP = 5.0  # Gradient clipping passed into theano.gradient.grad_clip()
-LEARNING_RATE = 1.0
+LEARNING_RATE = 1.0  # Learning rate for the chosen optimizer (currently using Adadelta, see model.py)
 
 # model params
 NN_MODEL_PREFIX = 'cakechat'  # specify prefix to be prepended to model's name

--- a/cakechat/dialog_model/factory.py
+++ b/cakechat/dialog_model/factory.py
@@ -1,9 +1,12 @@
 import os
 
+from cachetools import cached
+
 from cakechat.config import BASE_CORPUS_NAME, S3_MODELS_BUCKET_NAME, S3_TOKENS_IDX_REMOTE_DIR, \
     S3_NN_MODEL_REMOTE_DIR, S3_CONDITIONS_IDX_REMOTE_DIR
 from cakechat.dialog_model.model import get_nn_model
 from cakechat.utils.s3 import S3FileResolver
+from cakechat.utils.files_utils import FileNotFoundException
 from cakechat.utils.text_processing import get_index_to_token_path, load_index_to_item, get_index_to_condition_path
 
 
@@ -12,10 +15,10 @@ def _get_index_to_token(fetch_from_s3):
     if fetch_from_s3:
         tokens_idx_resolver = S3FileResolver(index_to_token_path, S3_MODELS_BUCKET_NAME, S3_TOKENS_IDX_REMOTE_DIR)
         if not tokens_idx_resolver.resolve():
-            raise Exception('Can\'t get index_to_token because file does not exist at S3')
+            raise FileNotFoundException('Can\'t get index_to_token because file does not exist at S3')
     else:
         if not os.path.exists(index_to_token_path):
-            raise Exception('Can\'t get index_to_token because file does not exist. '
+            raise FileNotFoundException('Can\'t get index_to_token because file does not exist. '
                             'Run tools/download_model.py first to get all required files or construct it by yourself.')
 
     return load_index_to_item(index_to_token_path)
@@ -27,15 +30,16 @@ def _get_index_to_condition(fetch_from_s3):
         index_to_condition_resolver = S3FileResolver(index_to_condition_path, S3_MODELS_BUCKET_NAME,
                                                      S3_CONDITIONS_IDX_REMOTE_DIR)
         if not index_to_condition_resolver.resolve():
-            raise Exception('Can\'t get index_to_condition because file does not exist at S3')
+            raise FileNotFoundException('Can\'t get index_to_condition because file does not exist at S3')
     else:
         if not os.path.exists(index_to_condition_path):
-            raise Exception('Can\'t get index_to_condition because file does not exist. '
+            raise FileNotFoundException('Can\'t get index_to_condition because file does not exist. '
                             'Run tools/download_model.py first to get all required files or construct it by yourself.')
 
     return load_index_to_item(index_to_condition_path)
 
 
+@cached(cache={})
 def get_trained_model(reverse=False, fetch_from_s3=True):
     if fetch_from_s3:
         resolver_factory = S3FileResolver.init_resolver(
@@ -43,14 +47,11 @@ def get_trained_model(reverse=False, fetch_from_s3=True):
     else:
         resolver_factory = None
 
-    nn_model, model_exists = get_nn_model(
-        _get_index_to_token(fetch_from_s3),
-        _get_index_to_condition(fetch_from_s3),
-        resolver_factory=resolver_factory,
-        is_reverse_model=reverse)
-
+    nn_model, model_exists = get_nn_model(index_to_token=_get_index_to_token(fetch_from_s3),
+                                          index_to_condition=_get_index_to_condition(fetch_from_s3),
+                                          resolver_factory=resolver_factory,
+                                          is_reverse_model=reverse)
     if not model_exists:
-        raise Exception('Can\'t get the model. '
-                        'Run tools/download_model.py first to get all required files or train it by yourself.')
-
+        raise FileNotFoundException('Can\'t get the pre-trained model. Run tools/download_model.py first '
+                                    'to get all required files or train it by yourself.')
     return nn_model

--- a/cakechat/dialog_model/inference/candidates/beamsearch.py
+++ b/cakechat/dialog_model/inference/candidates/beamsearch.py
@@ -1,7 +1,5 @@
-from six.moves import zip_longest
-
 import numpy as np
-from six.moves import xrange
+from six.moves import xrange, zip_longest
 import theano
 
 from cakechat.dialog_model.inference.candidates.abstract_generator import AbstractCandidatesGenerator
@@ -87,7 +85,7 @@ class BeamsearchCandidatesGenerator(AbstractCandidatesGenerator):
             # We need to get which original candidate this token in the expanded beam corresponds to.
             # (to fill in all the previous tokens from self._cur_candidates)
             # Because all the candidates in the expanded beam were filled sequentially, we just use this formula:
-            original_candidate_idx = candidate_idx / self._beam_size
+            original_candidate_idx = candidate_idx // self._beam_size
 
             # Construct the candidates for the next step using self._cur_candidates and the last token:
 
@@ -123,7 +121,7 @@ class BeamsearchCandidatesGenerator(AbstractCandidatesGenerator):
             # to get all the other tokens we need to get which original candidate this token in the expanded beam
             # corresponds to. Because all the candidates in the expanded beam were filled sequentially, we can just
             # use this formula:
-            original_candidate_idx = candidate_idx / self._beam_size
+            original_candidate_idx = candidate_idx // self._beam_size
 
             # Construct the candidates for the next step using self._cur_candidates and the last token:
 

--- a/cakechat/dialog_model/inference/factory.py
+++ b/cakechat/dialog_model/inference/factory.py
@@ -5,17 +5,6 @@ from cakechat.dialog_model.inference.predictor import Predictor
 from cakechat.dialog_model.inference.reranking import DummyReranker, MMIReranker
 
 
-def _get_reverse_model():
-    if not hasattr(_get_reverse_model, 'reverse_model'):
-        try:
-            reverse_model = get_trained_model(reverse=True)
-        except:
-            raise ValueError('Can\'t get reverse nn model for prediction. '
-                             'Try to run \'python tools/train.py --reverse\' or switch prediction mode to sampling.')
-        _get_reverse_model.reverse_model = reverse_model
-    return _get_reverse_model.reverse_model
-
-
 def predictor_factory(nn_model, mode, config):
     """
 
@@ -39,7 +28,7 @@ def predictor_factory(nn_model, mode, config):
         if config['mmi_reverse_model_score_weight'] <= 0:
             raise ValueError('mmi_reverse_model_score_weight should be > 0 for reranking mode')
 
-        reverse_model = _get_reverse_model()
+        reverse_model = get_trained_model(reverse=True)
         reranker = MMIReranker(nn_model, reverse_model, config['mmi_reverse_model_score_weight'],
                                config['repetition_penalization_coefficient'])
     else:

--- a/cakechat/dialog_model/inference/predictor.py
+++ b/cakechat/dialog_model/inference/predictor.py
@@ -15,11 +15,11 @@ class Predictor(object):
         If for some context we generated less then candidates_num candidates, we fill this responses with pads.
         """
         batch_size = len(reranked_candidates)
-        # reranked_candidates is list of lists (we need too keep it this way because we can have different number
-        # of candidates for each context), so we can't just write rerankied_candidates.shape[2]
+        # reranked_candidates is a list of lists (we need too keep it this way because we can have different number
+        # of candidates for each context), so we can't just write reranked_candidates.shape[2]
         output_seq_len = reranked_candidates[0][0].size
-        result = np.zeros((batch_size, candidates_num, output_seq_len))
-        # Loop here instead of slices because number of candidates for each context can vary here
+        result = np.zeros((batch_size, candidates_num, output_seq_len), dtype=np.int32)
+        # Loop here instead of slices because number of candidates for each context may vary here
         for i in xrange(batch_size):
             for j, candidate in enumerate(reranked_candidates[i]):
                 if j >= candidates_num:
@@ -30,4 +30,5 @@ class Predictor(object):
     def predict_responses(self, context_token_ids, output_seq_len, condition_ids=None, candidates_num=1):
         all_candidates = self._generator.generate_candidates(context_token_ids, condition_ids, output_seq_len)
         reranked_candidates = self._reranker.rerank_candidates(context_token_ids, all_candidates, condition_ids)
-        return self._select_best_candidates(reranked_candidates, candidates_num)
+        selected_responses = self._select_best_candidates(reranked_candidates, candidates_num)
+        return selected_responses

--- a/cakechat/dialog_model/inference/tests/predict.py
+++ b/cakechat/dialog_model/inference/tests/predict.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+
 import numpy as np
 from six.moves import xrange
 

--- a/cakechat/dialog_model/model.py
+++ b/cakechat/dialog_model/model.py
@@ -11,13 +11,14 @@ from lasagne.layers import InputLayer, DenseLayer, GRULayer, reshape, EmbeddingL
     DropoutLayer, get_output, get_all_params, get_all_param_values, set_all_param_values, get_all_layers, \
     get_output_shape
 from lasagne.objectives import categorical_crossentropy
+from six.moves import xrange
 
-from cakechat.config import HIDDEN_LAYER_DIMENSION, GRAD_CLIP, ADADELTA_LEARNING_RATE, \
+from cakechat.config import HIDDEN_LAYER_DIMENSION, GRAD_CLIP, LEARNING_RATE, \
     TRAIN_WORD_EMBEDDINGS_LAYER, WORD_EMBEDDING_DIMENSION, ENCODER_DEPTH, DECODER_DEPTH, DENSE_DROPOUT_RATIO, \
-    CONDITION_EMBEDDING_DIMENSION
+    CONDITION_EMBEDDING_DIMENSION, NN_MODEL_PREFIX, BASE_CORPUS_NAME, INPUT_CONTEXT_SIZE, INPUT_SEQUENCE_LENGTH, \
+    OUTPUT_SEQUENCE_LENGTH, NN_MODELS_DIR
 from cakechat.dialog_model.layers import RepeatLayer, NotEqualMaskLayer, SwitchLayer
-from cakechat.dialog_model.model_utils import get_model_full_path
-from cakechat.utils.files_utils import DummyFileResolver, ensure_dir
+from cakechat.utils.files_utils import DummyFileResolver, ensure_dir, FileNotFoundException
 from cakechat.utils.logger import get_logger, laconic_logger
 from cakechat.utils.text_processing import SPECIAL_TOKENS
 
@@ -28,8 +29,12 @@ class CakeChatModel(object):
     def __init__(self,
                  index_to_token,
                  index_to_condition,
+                 model_init_path=None,
+                 nn_models_dir=NN_MODELS_DIR,
+                 model_prefix=NN_MODEL_PREFIX,
+                 corpus_name=BASE_CORPUS_NAME,
                  skip_token=SPECIAL_TOKENS.PAD_TOKEN,
-                 learning_rate=ADADELTA_LEARNING_RATE,
+                 learning_rate=LEARNING_RATE,
                  grad_clip=GRAD_CLIP,
                  hidden_layer_dim=HIDDEN_LAYER_DIMENSION,
                  encoder_depth=ENCODER_DEPTH,
@@ -38,14 +43,16 @@ class CakeChatModel(object):
                  word_embedding_dim=WORD_EMBEDDING_DIMENSION,
                  train_word_embedding=TRAIN_WORD_EMBEDDINGS_LAYER,
                  dense_dropout_ratio=DENSE_DROPOUT_RATIO,
-                 condition_embedding_dim=CONDITION_EMBEDDING_DIMENSION):
+                 condition_embedding_dim=CONDITION_EMBEDDING_DIMENSION,
+                 is_reverse_model=False):
         """
         :param index_to_token: Dict with tokens and indices for neural network
-        :param skip_token: Token to skip with masking. Id of this token is inferred from index_to_token dictionary.
-        :param learning_rate: Starting learning rate for the optimization algorithm
-        :param grad_clip: Clipping parameter to prevent gradient explosion.
+        :param model_init_path: Path to weights file to be used for model's intialization
+        :param skip_token: Token to skip with masking. Id of this token is inferred from index_to_token dictionary
+        :param learning_rate: Learning rate factor for the optimization algorithm
+        :param grad_clip: Clipping parameter to prevent gradient explosion
         :param init_embedding: Matrix to initialize word-embedding layer. Default value is random standart-gaussian
-            initialization.
+            initialization
         """
         self._index_to_token = index_to_token
         self._token_to_index = {v: k for k, v in index_to_token.items()}
@@ -69,9 +76,59 @@ class CakeChatModel(object):
         self._decoder_depth = decoder_depth
         self._dense_dropout_ratio = dense_dropout_ratio
 
+        self._nn_models_dir = nn_models_dir
+        self._model_prefix = model_prefix
+        self._corpus_name = corpus_name
+        self._is_reverse_model = is_reverse_model
+
+        self._model_load_path = model_init_path or self.model_save_path
+
         self._train_fn = None  # Training functions are compiled as needed
         self._build_model_computational_graph()
         self._compile_theano_functions_for_prediction()
+
+    @property
+    def params_str(self):
+        params_str = 'gru' \
+                     '_hd{hidden_dim}' \
+                     '_cdim{condition_dimension}' \
+                     '_drop{dropout_ratio}' \
+                     '_encd{encoder_depth}' \
+                     '_decd{decoder_depth}' \
+                     '_il{input_seq_len}' \
+                     '_cs{input_cont_size}' \
+                     '_ansl{output_seq_len}' \
+                     '_lr{learning_rate}' \
+                     '_gc{gradient_clip}' \
+                     '_{learn_emb}'
+
+        return params_str.format(
+            hidden_dim=self._hidden_layer_dim,
+            condition_dimension=self._condition_embedding_dim,
+            encoder_depth=self._encoder_depth,
+            decoder_depth=self._decoder_depth,
+            input_seq_len=INPUT_SEQUENCE_LENGTH,
+            input_cont_size=INPUT_CONTEXT_SIZE,
+            output_seq_len=OUTPUT_SEQUENCE_LENGTH,
+            dropout_ratio=self._dense_dropout_ratio,
+            learning_rate=self._learning_rate,
+            gradient_clip=self._grad_clip,
+            learn_emb='learnemb' if self._train_word_embedding else 'fixemb'
+        )
+
+    @property
+    def model_name(self):
+        suffix = ['reverse'] if self._is_reverse_model else []
+        params_str = '_'.join([
+            self._model_prefix,
+            self._corpus_name,
+            self.params_str
+        ] + suffix)
+        return params_str
+
+    @property
+    def model_save_path(self):
+        return os.path.join(self._nn_models_dir, self.model_name)
 
     def _build_model_computational_graph(self):
         self._net = OrderedDict()
@@ -98,7 +155,8 @@ class CakeChatModel(object):
 
         self._net['input_y'] = InputLayer(shape=(None, None), input_var=T.imatrix(name='input_y'), name='input_y')
 
-        # These are theano variables and they are computed dynamically as data is passed into the computational graph
+        # Infer these variables from data passed to computation graph
+        # since batch shape may differ in training and prediction phases
         self._batch_size = self._net['input_x'].input_var.shape[0]
         self._input_context_size = self._net['input_x'].input_var.shape[1]
         self._input_seq_len = self._net['input_x'].input_var.shape[2]
@@ -541,6 +599,10 @@ class CakeChatModel(object):
         return self._token_to_index
 
     @property
+    def model_load_path(self):
+        return self._model_load_path
+
+    @property
     def vocab_size(self):
         return self._vocab_size
 
@@ -556,18 +618,34 @@ class CakeChatModel(object):
     def decoder_depth(self):
         return self._decoder_depth
 
-    def load_weights(self, model_path):
-        with open(model_path, 'rb') as f:
+    @property
+    def is_reverse_model(self):
+        return self._is_reverse_model
+
+    def load_weights(self):
+        with open(self.model_load_path, 'rb') as f:
             loaded_file = np.load(f)
             # Just using .values() would't work here because we need to keep the order of elements
             ordered_params = [loaded_file['arr_%d' % i] for i in xrange(len(loaded_file.files))]
         set_all_param_values(self._net['dist'], ordered_params)
 
-    def save_weights(self, save_path):
-        ensure_dir(os.path.dirname(save_path))
+    def save_model(self, save_model_path):
+        ensure_dir(os.path.dirname(save_model_path))
         ordered_params = get_all_param_values(self._net['dist'])
-        with open(save_path, 'wb') as f:
+
+        with open(save_model_path, 'wb') as f:
             np.savez(f, *ordered_params)
+
+        _logger.info('\nSaved model:\n{}\n'.format(save_model_path))
+
+    @staticmethod
+    def delete_model(delete_path):
+        if not os.path.isfile(delete_path):
+            _logger.warning('Couldn\'t delete model. File not found:\n"{}"'.format(delete_path))
+            return
+
+        os.remove(delete_path)
+        _logger.info('\nModel is deleted:\n{}'.format(delete_path))
 
     def print_layer_shapes(self):
         laconic_logger.info('Net shapes:')
@@ -577,7 +655,7 @@ class CakeChatModel(object):
             laconic_logger.info('\t%-20s \t%s' % (l.name, get_output_shape(l)))
 
     def print_matrices_weights(self):
-        laconic_logger.info('Net matrices weights:')
+        laconic_logger.info('\nNet matrices weights:')
         params = get_all_params(self._net['dist'])
         values = get_all_param_values(self._net['dist'])
 
@@ -592,39 +670,29 @@ class CakeChatModel(object):
         laconic_logger.info('Total network size: {0:.1f} Mb'.format(total_network_size))
 
 
-def get_nn_model(index_to_token,
-                 index_to_condition,
-                 w2v_matrix=None,
-                 resolver_factory=None,
-                 nn_model_path=None,
+def get_nn_model(index_to_token, index_to_condition, model_init_path=None, w2v_matrix=None, resolver_factory=None,
                  is_reverse_model=False):
-    _logger.info('Initializing NN model with the following params:')
-    _logger.info(
-        'NN input dimension: {} (token vector size)'.format(WORD_EMBEDDING_DIMENSION + CONDITION_EMBEDDING_DIMENSION))
-    _logger.info('NN hidden dimension: {}'.format(HIDDEN_LAYER_DIMENSION))
-    _logger.info('NN output dimension: {} (dict size)'.format(len(index_to_token)))
+    model = CakeChatModel(index_to_token,
+                          index_to_condition,
+                          model_init_path=model_init_path,
+                          init_embedding=w2v_matrix,
+                          is_reverse_model=is_reverse_model)
 
-    if w2v_matrix is not None:
-        w2v_matrix = w2v_matrix.astype(theano.config.floatX)
+    model.print_layer_shapes()
 
-    model = CakeChatModel(index_to_token, index_to_condition, init_embedding=w2v_matrix)
-
-    if not nn_model_path:
-        nn_model_path = get_model_full_path(is_reverse_model)
-
-    resolver = resolver_factory(nn_model_path) if resolver_factory else DummyFileResolver(nn_model_path)
+    # try to initialise model with pre-trained weights
+    resolver = resolver_factory(model.model_load_path) if resolver_factory else DummyFileResolver(model.model_load_path)
     model_exists = resolver.resolve()
 
     if model_exists:
-        _logger.info('Loading previously calculated weights from {}...'.format(nn_model_path))
-        model.load_weights(nn_model_path)
+        _logger.info('\nLoading weights from file:\n{}\n'.format(model.model_load_path))
+        model.load_weights()
+    elif model_init_path:
+        raise FileNotFoundException('Can\'t initialize model from file:\n{}\n'.format(model_init_path))
     else:
-        _logger.info("Can't find previously calculated model, so will use a fresh one")
+        _logger.info('\nModel will be built with initial weights.\n')
 
-    _logger.info('Model is built\n')
-    model.print_layer_shapes()
     model.print_matrices_weights()
-
-    _logger.info('Model path is {}'.format(nn_model_path))
+    _logger.info('\nModel is built\n')
 
     return model, model_exists

--- a/cakechat/dialog_model/model.py
+++ b/cakechat/dialog_model/model.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 
 import lasagne
 import numpy as np
-from six.moves import xrange
 import theano
 import theano.tensor as T
 from lasagne.init import Normal
@@ -155,8 +154,8 @@ class CakeChatModel(object):
 
         self._net['input_y'] = InputLayer(shape=(None, None), input_var=T.imatrix(name='input_y'), name='input_y')
 
-        # Infer these variables from data passed to computation graph
-        # since batch shape may differ in training and prediction phases
+        # Infer these variables from data passed to computation graph since batch shape may differ in training and
+        # prediction phases
         self._batch_size = self._net['input_x'].input_var.shape[0]
         self._input_context_size = self._net['input_x'].input_var.shape[1]
         self._input_seq_len = self._net['input_x'].input_var.shape[2]

--- a/cakechat/dialog_model/model_utils.py
+++ b/cakechat/dialog_model/model_utils.py
@@ -204,7 +204,7 @@ def transform_w2v_model_to_matrix(w2v_model, index_to_token):
 
     token_to_index = {v: k for k, v in index_to_token.items()}
     tokens_num = len(index_to_token)
-    output = np.zeros((tokens_num, WORD_EMBEDDING_DIMENSION))
+    output = np.zeros((tokens_num, WORD_EMBEDDING_DIMENSION), dtype=np.float32)
     for token in index_to_token.values():
         idx = token_to_index[token]
         output[idx] = _get_token_vector(token, w2v_model)

--- a/cakechat/dialog_model/model_utils.py
+++ b/cakechat/dialog_model/model_utils.py
@@ -6,20 +6,16 @@ import numpy as np
 from six import text_type
 from six.moves import xrange, map, zip
 
-from cakechat.config import BASE_CORPUS_NAME, TRAIN_CORPUS_NAME, WORD_EMBEDDING_DIMENSION, INPUT_CONTEXT_SIZE, \
-    HIDDEN_LAYER_DIMENSION, ENCODER_DEPTH, DECODER_DEPTH, INPUT_SEQUENCE_LENGTH, \
-    OUTPUT_SEQUENCE_LENGTH, GRAD_CLIP, ADADELTA_LEARNING_RATE, TRAIN_WORD_EMBEDDINGS_LAYER, DATA_DIR, \
-    DENSE_DROPOUT_RATIO, USE_SKIP_GRAM, W2V_WINDOW_SIZE, CONDITION_EMBEDDING_DIMENSION, DEFAULT_CONDITION, \
-    S3_MODELS_BUCKET_NAME, S3_W2V_REMOTE_DIR
+from cakechat.config import TRAIN_CORPUS_NAME, WORD_EMBEDDING_DIMENSION, INPUT_CONTEXT_SIZE, INPUT_SEQUENCE_LENGTH, DEFAULT_CONDITION, \
+    S3_MODELS_BUCKET_NAME, S3_W2V_REMOTE_DIR, OUTPUT_SEQUENCE_LENGTH, W2V_WINDOW_SIZE, USE_SKIP_GRAM
+from cakechat.utils.data_types import Dataset
 from cakechat.utils.logger import get_logger
 from cakechat.utils.s3 import S3FileResolver
 from cakechat.utils.tee_file import file_buffered_tee
-from cakechat.utils.text_processing import SPECIAL_TOKENS, load_index_to_item, get_index_to_token_path
-from cakechat.utils.w2v import get_w2v_model, get_w2v_params_str
+from cakechat.utils.text_processing import SPECIAL_TOKENS
+from cakechat.utils.w2v import get_w2v_model
 
 _logger = get_logger(__name__)
-
-Dataset = namedtuple('Dataset', ['x', 'y', 'condition_ids'])
 
 
 def transform_conditions_to_ids(conditions, condition_to_index, n_dialogs):
@@ -126,9 +122,9 @@ def transform_token_ids_to_sentences(y_ids, index_to_token):
     Transformation of each sentence ends when the end_token occurred.
     Skips start tokens.
 
-    :param y_ids: numpy array N_LINES x N_TOKENS, containing ids of all tokens to use
-    :param index_to_token: dictionary used for transforming
-    :return:
+    :param y_ids: numpy array of integers, shape (lines_num, tokens_num), represents token ids
+    :param index_to_token: dictionary to be used for transforming
+    :return: list of strings, list length = lines_num
     """
     n_responses, n_tokens = y_ids.shape
 
@@ -158,7 +154,7 @@ def transform_context_token_ids_to_sentences(x_ids, index_to_token):
     Transformation of each sentence ends when the end_token occurred.
     Skips start tokens.
 
-    :param x_ids: numpy array N_LINES x N_CONTEXTS x N_TOKENS, containing ids of all tokens to use
+    :param x_ids: context token ids, numpy array of shape (batch_size, context_len, tokens_num)
     :param index_to_token:
     :return:
     """
@@ -194,7 +190,7 @@ def _get_token_vector(token, w2v_model):
     elif token == SPECIAL_TOKENS.PAD_TOKEN:
         return np.zeros(w2v_model.vector_size)
     else:
-        _logger.warn('Can\'t find token [%s] in w2v dict' % token)
+        _logger.warning('Can\'t find token [%s] in w2v dict' % token)
         if not hasattr(_get_token_vector, 'unk_vector'):
             if SPECIAL_TOKENS.UNKNOWN_TOKEN in w2v_model.wv.vocab:
                 _get_token_vector.unk_vector = np.array(w2v_model[SPECIAL_TOKENS.UNKNOWN_TOKEN])
@@ -257,53 +253,6 @@ def get_training_batch(inputs, batch_size, random_permute=False):
         samples_ids = samples_seq[seen_samples_num:]
         # yield the rest of x and y sequences
         yield tuple(inp[samples_ids] for inp in inputs)
-
-
-def _get_nn_params_str():
-    params_str = 'gru' \
-                 '_hd{hidden_dim}' \
-                 '_drop{dropout_ratio}' \
-                 '_encd{encoder_depth}' \
-                 '_decd{decoder_depth}' \
-                 '_il{input_len}' \
-                 '_cs{context_size}' \
-                 '_ansl{ans_len}' \
-                 '_lr{learning_rate}' \
-                 '_gc_{gradient_clip}' \
-                 '_{learn_emb}' \
-                 '_cdim{condition_dimension}'
-
-    params_str = params_str.format(
-        hidden_dim=HIDDEN_LAYER_DIMENSION,
-        condition_dimension=CONDITION_EMBEDDING_DIMENSION,
-        encoder_depth=ENCODER_DEPTH,
-        decoder_depth=DECODER_DEPTH,
-        dropout_ratio=DENSE_DROPOUT_RATIO,
-        input_len=INPUT_SEQUENCE_LENGTH,
-        context_size=INPUT_CONTEXT_SIZE,
-        ans_len=OUTPUT_SEQUENCE_LENGTH,
-        learning_rate=ADADELTA_LEARNING_RATE,
-        gradient_clip=GRAD_CLIP,
-        learn_emb='learnemb' if TRAIN_WORD_EMBEDDINGS_LAYER else 'fixedemb')
-    return params_str
-
-
-def get_model_vocab_size():
-    index_to_token_path = get_index_to_token_path(BASE_CORPUS_NAME)
-    index_to_token = load_index_to_item(index_to_token_path)
-    return len(index_to_token)
-
-
-def get_model_full_params_str(is_reverse_model=False):
-    w2v_params_str = get_w2v_params_str(
-        get_model_vocab_size(), vec_size=WORD_EMBEDDING_DIMENSION, window_size=W2V_WINDOW_SIZE, skip_gram=USE_SKIP_GRAM)
-    reverse_suffix = ['reverse'] if is_reverse_model else []
-    return '_'.join([BASE_CORPUS_NAME, _get_nn_params_str(), w2v_params_str] + reverse_suffix)
-
-
-def get_model_full_path(is_reverse_model=False):
-    nn_model_path = os.path.join(DATA_DIR, 'nn_models', get_model_full_params_str(is_reverse_model))
-    return nn_model_path
 
 
 def reverse_nn_input(dataset, service_tokens):

--- a/cakechat/dialog_model/model_utils.py
+++ b/cakechat/dialog_model/model_utils.py
@@ -1,8 +1,7 @@
-import os
-from collections import namedtuple
 from itertools import islice
 
 import numpy as np
+import theano
 from six import text_type
 from six.moves import xrange, map, zip
 
@@ -204,7 +203,7 @@ def transform_w2v_model_to_matrix(w2v_model, index_to_token):
 
     token_to_index = {v: k for k, v in index_to_token.items()}
     tokens_num = len(index_to_token)
-    output = np.zeros((tokens_num, WORD_EMBEDDING_DIMENSION), dtype=np.float32)
+    output = np.zeros((tokens_num, WORD_EMBEDDING_DIMENSION), dtype=theano.config.floatX)
     for token in index_to_token.values():
         idx = token_to_index[token]
         output[idx] = _get_token_vector(token, w2v_model)

--- a/cakechat/dialog_model/quality/logging.py
+++ b/cakechat/dialog_model/quality/logging.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from six.moves import xrange
+import pandas as pd
 
 # UnicodeCSV requires files to be opened as binary on Python3 by design.
 # https://github.com/jdunck/python-unicodecsv/issues/65
@@ -14,9 +15,9 @@ if sys.version_info[0] == 2:
 else:
     import csv
 
-from cakechat.config import DATA_DIR, PREDICTION_MODE_FOR_TESTS, LOG_CANDIDATES_NUM, MAX_PREDICTIONS_LENGTH
+from cakechat.config import DATA_DIR, PREDICTION_MODE_FOR_TESTS, MAX_PREDICTIONS_LENGTH
 from cakechat.dialog_model.inference import get_nn_responses
-from cakechat.dialog_model.model_utils import transform_context_token_ids_to_sentences, get_model_full_params_str
+from cakechat.dialog_model.model_utils import transform_context_token_ids_to_sentences
 from cakechat.dialog_model.quality import calculate_model_mean_perplexity, calculate_response_ngram_distinctness
 from cakechat.utils.files_utils import ensure_dir
 from cakechat.utils.logger import get_logger
@@ -24,10 +25,7 @@ from cakechat.utils.plotters import TensorboardMetricsPlotter
 
 _StatsInfo = namedtuple('StatsInfo', 'start_time, iteration_num, sents_batches_num')
 
-_NN_MODEL_PARAMS_STR = get_model_full_params_str()
-
 _TENSORBOARD_LOG_DIR = os.path.join(DATA_DIR, 'tensorboard')
-_TEST_RESULTS_PATH = os.path.join(DATA_DIR, 'results', _NN_MODEL_PARAMS_STR + '.tsv')
 _METRIC_NAMES = ['perplexity', 'unigram_distinctness', 'bigram_distinctness']
 
 _logger = get_logger(__name__)
@@ -52,7 +50,7 @@ def _get_iteration_stats(stats_info):
     total_elapsed_time = time.time() - stats_info.start_time
     stats_str += 'Total elapsed time: %s\n' % _get_formatted_time(total_elapsed_time)
 
-    elapsed_time_per_iteration = total_elapsed_time / stats_info.iteration_num
+    elapsed_time_per_iteration = total_elapsed_time / (stats_info.iteration_num + 1)
     stats_str += 'Elapsed time for a batch: %s\n' % _get_formatted_time(elapsed_time_per_iteration)
 
     estimated_time_for_full_pass = elapsed_time_per_iteration * stats_info.sents_batches_num
@@ -61,21 +59,20 @@ def _get_iteration_stats(stats_info):
     return stats_str
 
 
-def init_csv_writer(fh, mode, output_seq_len):
+def init_csv_writer(fh, output_seq_len, model_params_str):
     csv_writer = csv.writer(fh, delimiter='\t')
     csv_writer.writerow([''])  # empty row for better readability
-    csv_writer.writerow([_NN_MODEL_PARAMS_STR])
+    csv_writer.writerow([model_params_str])
     csv_writer.writerow(['commit hash: %s' % _get_git_revision_short_hash()])
     csv_writer.writerow(['date: %s' % datetime.now().strftime("%Y-%m-%d_l%H:%M")])
-    csv_writer.writerow(['Prediction using %s' % mode])
     csv_writer.writerow(['%d maximum tokens in the response' % output_seq_len])
 
     return csv_writer
 
 
-def save_metrics(metrics):
-    for name, value in metrics.items():
-        _tensorboard_metrics_plotter.plot(model_name=_NN_MODEL_PARAMS_STR, metric_name=name, metric_value=float(value))
+def save_metrics(metrics, model_name):
+    for metric_name, metric_value in metrics.items():
+        _tensorboard_metrics_plotter.plot(model_name, metric_name, float(metric_value))
 
 
 def calculate_and_log_val_metrics(nn_model,
@@ -83,31 +80,58 @@ def calculate_and_log_val_metrics(nn_model,
                                   context_free_val,
                                   prediction_mode=PREDICTION_MODE_FOR_TESTS):
     val_metrics = dict()
-    val_metrics['context_sensitive_perplexity'] = calculate_model_mean_perplexity(nn_model,
-                                                                                  context_sensitive_val_subset)
+
     val_metrics['context_free_perplexity'] = calculate_model_mean_perplexity(nn_model, context_free_val)
+    _logger.info('Current val context-free perplexity: {0:.2f}'.format(val_metrics['context_free_perplexity']))
+
+    val_metrics['context_sensitive_perplexity'] = \
+        calculate_model_mean_perplexity(nn_model, context_sensitive_val_subset)
+    _logger.info('Current val context-sensitive perplexity: {0:.2f}'
+                 .format(val_metrics['context_sensitive_perplexity']))
 
     val_metrics['unigram_distinctness'] = calculate_response_ngram_distinctness(
-        context_sensitive_val_subset.x, nn_model, ngram_len=1, mode=prediction_mode)
-    val_metrics['bigram_distinctness'] = calculate_response_ngram_distinctness(
-        context_sensitive_val_subset.x, nn_model, ngram_len=2, mode=prediction_mode)
+        context_sensitive_val_subset.x,
+        nn_model,
+        ngram_len=1,
+        mode=prediction_mode,
+        condition_ids=context_sensitive_val_subset.condition_ids)
 
-    _logger.info('Current val context-sensitive perplexity: %s' % val_metrics['context_sensitive_perplexity'])
-    _logger.info('Current val context-free perplexity: %s' % val_metrics['context_free_perplexity'])
-    _logger.info('Current val distinctness: uni=%s, bi=%s' % (val_metrics['unigram_distinctness'],
-                                                              val_metrics['bigram_distinctness']))
+    val_metrics['bigram_distinctness'] = calculate_response_ngram_distinctness(
+        context_sensitive_val_subset.x,
+        nn_model,
+        ngram_len=2,
+        mode=prediction_mode,
+        condition_ids=context_sensitive_val_subset.condition_ids)
+
+    _logger.info('Current val distinctness: uni={0:.3f}, bi={1:.3f}'.format(val_metrics['unigram_distinctness'],
+                                                                            val_metrics['bigram_distinctness']))
+
     return val_metrics
 
 
 def log_predictions(predictions_path,
                     x_test,
                     nn_model,
-                    mode,
-                    candidates_num=None,
+                    prediction_modes=(PREDICTION_MODE_FOR_TESTS,),
                     stats_info=None,
                     cur_perplexity=None,
                     output_seq_len=MAX_PREDICTIONS_LENGTH,
                     **kwargs):
+    """
+    Generate responses for provided contexts and save the results on the disk. For a given context
+    several responses will be generated - one for each mode from the prediction_modes list.
+
+    :param predictions_path: Generated responses will be saved to this file
+    :param x_test: context token ids, numpy array of shape (batch_size, context_len, INPUT_SEQUENCE_LENGTH)
+    :param nn_model: instance of CakeChatModel class
+    :param prediction_modes: Iterable of modes to be used for responses generation. See PREDICTION_MODES
+                             for available options
+    :param stats_info: Info about current training status: total time passed, time spent on training,
+                       processed batches number and estimated time for one epoch
+    :param cur_perplexity: Addition to stats_info - current perplexity metric calculated on validation dataset
+    :param output_seq_len: Max number of tokens in generated responses
+    """
+
     _logger.info('Logging responses to test lines')
 
     # Create all the directories for the prediction path in case they don't exist
@@ -116,46 +140,35 @@ def log_predictions(predictions_path,
         ensure_dir(prediction_dir)
 
     with open(predictions_path, 'w') as test_res_fh:
-        csv_writer = init_csv_writer(test_res_fh, mode, output_seq_len)
+        csv_writer = init_csv_writer(test_res_fh, output_seq_len, nn_model.model_name)
 
         if cur_perplexity:
             csv_writer.writerow(['Current perplexity: %.2f' % cur_perplexity])
         if stats_info:
             csv_writer.writerow([_get_iteration_stats(stats_info)])
 
-        csv_writer.writerow(['input sentence'] + ['candidate #{}'.format(v + 1) for v in xrange(candidates_num)])
+    contexts = transform_context_token_ids_to_sentences(x_test, nn_model.index_to_token)
+    predictions_data = pd.DataFrame()
+    predictions_data['contexts'] = contexts
 
-        questions = transform_context_token_ids_to_sentences(x_test, nn_model.index_to_token)
+    for pred_mode in prediction_modes:
+        responses_batch = get_nn_responses(x_test, nn_model, pred_mode, **kwargs)
+        # list of lists of strings, shape (contexts_num, 1)
+        first_responses_batch = [response[0] for response in responses_batch]
+        # list of strings, shape (contexts_num)
+        predictions_data[pred_mode] = first_responses_batch
 
-        _logger.info('Start predicting responses of length {out_len} for {n_samples} samples with mode {mode}'.format(
-            out_len=output_seq_len, n_samples=x_test.shape[0], mode=mode))
+    predictions_data.to_csv(predictions_path, sep='\t', index=False, encoding='utf-8', mode='a', float_format='%.2f')
 
-        nn_responses = get_nn_responses(x_test, nn_model, mode, candidates_num, output_seq_len, **kwargs)
-
-        _logger.info('Logging generated predictions...')
-        for idx, (question, responses) in enumerate(zip(questions, nn_responses)):
-            csv_writer.writerow([question] + responses)
-
-        _logger.info('Succesfully dumped {n_resp} of {n_resp} responses'.format(n_resp=len(questions)))
-        _logger.info('Here they are: {}'.format(predictions_path))
+    message = '\nSuccesfully dumped {} responses.'.format(len(contexts))
+    message += '\nHere they are:\n{}\n'.format(predictions_path)
+    _logger.info(message)
 
 
-def save_test_results(x_test,
-                      nn_model,
-                      start_time,
-                      current_batch_idx,
-                      all_batches_num,
-                      suffix='',
-                      cur_perplexity=None,
-                      prediction_mode=PREDICTION_MODE_FOR_TESTS):
+def save_test_results(x_test, nn_model, start_time, current_batch_idx, all_batches_num, suffix='', cur_perplexity=None):
+
     stats_info = _StatsInfo(start_time, current_batch_idx, all_batches_num)
-    test_results_path = _TEST_RESULTS_PATH.replace('.tsv', '%s.tsv' % suffix)
+    results_file_name = '{}_{}.tsv'.format(nn_model.model_name, suffix)
+    test_results_path = os.path.join(DATA_DIR, 'results', results_file_name)
 
-    log_predictions(
-        test_results_path,
-        x_test,
-        nn_model,
-        mode=prediction_mode,
-        candidates_num=LOG_CANDIDATES_NUM,
-        stats_info=stats_info,
-        cur_perplexity=cur_perplexity)
+    log_predictions(test_results_path, x_test, nn_model, stats_info=stats_info, cur_perplexity=cur_perplexity)

--- a/cakechat/dialog_model/quality/metrics/distinctness.py
+++ b/cakechat/dialog_model/quality/metrics/distinctness.py
@@ -1,7 +1,6 @@
 import numpy as np
 from six.moves import xrange
 
-
 from cakechat.config import PREDICTION_MODE_FOR_TESTS, DEFAULT_TEMPERATURE, BEAM_SIZE, \
     PREDICTION_DISTINCTNESS_NUM_TOKENS
 from cakechat.dialog_model.inference import get_nn_response_ids, ServiceTokensIDs

--- a/cakechat/dialog_model/quality/metrics/lexical_simlarity.py
+++ b/cakechat/dialog_model/quality/metrics/lexical_simlarity.py
@@ -3,11 +3,10 @@ import os
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 from cakechat.config import TRAIN_CORPUS_NAME, BASE_CORPUS_NAME, DATA_DIR
-from cakechat.dialog_model.model_utils import get_index_to_token_path
 from cakechat.utils.files_utils import get_persisted
 from cakechat.utils.text_processing import load_index_to_item, get_tokens_sequence, get_processed_corpus_path, \
     load_processed_dialogs_from_json, FileTextLinesIterator, get_dialog_lines_and_conditions, \
-    get_alternated_dialogs_lines
+    get_alternated_dialogs_lines, get_index_to_token_path
 
 _TFIDF_VECTORIZER_FULL_PATH = os.path.join(DATA_DIR, 'tfidf_vectorizer.pickle')
 

--- a/cakechat/dialog_model/train.py
+++ b/cakechat/dialog_model/train.py
@@ -1,17 +1,18 @@
-import os
 import time
 
 from six.moves import xrange
 
-from cakechat.config import MAX_PREDICTIONS_LENGTH, BATCH_SIZE, EPOCHES_NUM, LOG_FREQUENCY_PER_BATCHES, \
+from cakechat.config import MAX_PREDICTIONS_LENGTH, BATCH_SIZE, EPOCHS_NUM, LOG_TO_TB_FREQUENCY_PER_BATCHES, \
     SCREEN_LOG_FREQUENCY_PER_BATCHES, SCREEN_LOG_NUM_TEST_LINES, SHUFFLE_TRAINING_BATCHES, PREDICTION_MODE_FOR_TESTS, \
-    PREDICTION_MODES, LOG_CANDIDATES_NUM, VAL_SUBSET_SIZE, LOG_LOSS_DECAY
+    LOG_CANDIDATES_NUM, VAL_SUBSET_SIZE, AVG_LOSS_DECAY, LOG_TO_FILE_FREQUENCY_PER_BATCHES, \
+    SAVE_MODEL_FREQUENCY_PER_BATCHES
 from cakechat.dialog_model.inference import get_nn_responses
 from cakechat.dialog_model.inference.service_tokens import ServiceTokensIDs
 from cakechat.dialog_model.model_utils import transform_context_token_ids_to_sentences, get_training_batch, \
-    get_model_full_path, reverse_nn_input
+    reverse_nn_input
 from cakechat.dialog_model.quality import save_metrics, save_test_results, calculate_and_log_val_metrics, \
     calculate_model_mean_perplexity
+from cakechat.utils.data_types import TrainStats, DatasetsCollection
 from cakechat.utils.dataset_loader import load_context_free_val, load_conditioned_train_set, \
     generate_subset, load_context_sensitive_val
 from cakechat.utils.logger import get_logger, laconic_logger
@@ -19,31 +20,25 @@ from cakechat.utils.logger import get_logger, laconic_logger
 _logger = get_logger(__name__)
 
 
-def _save_model(nn_model, model_path):
-    _logger.info('Saving model...')
-    nn_model.save_weights(model_path)
-    _logger.info('Model is saved:\n%s' % model_path)
+def _update_saved_nn_model(nn_model, val_metrics, best_perplexities, train_stats):
+    if train_stats.cur_batch_id % SAVE_MODEL_FREQUENCY_PER_BATCHES != 0:
+        # don't save model on this iteration
+        return best_perplexities
 
+    # proceed with model saving
+    cur_perplexities = (val_metrics['context_free_perplexity'], val_metrics['context_sensitive_perplexity'])
+    is_perplexity_improved = cur_perplexities[0] < best_perplexities[0] and cur_perplexities[1] < best_perplexities[1]
 
-def _delete_model(model_path):
-    if os.path.isfile(model_path):
-        _logger.info('Deleting old model...')
-        os.remove(model_path)
-        _logger.info('Model is deleted:\n%s' % model_path)
-
-
-def _update_saved_nn_model(nn_model, cur_perplexities, best_perplexities, is_reverse_model=False):
-    model_path = get_model_full_path(is_reverse_model)
-    if all((cur < best) for cur, best in zip(cur_perplexities, best_perplexities)):
+    if is_perplexity_improved:
         old_suffix = '_pp_free{0:.2f}_sensitive{1:.2f}'.format(*best_perplexities)
         new_suffix = '_pp_free{0:.2f}_sensitive{1:.2f}'.format(*cur_perplexities)
         best_perplexities = cur_perplexities
-        _save_model(nn_model, model_path + new_suffix)
+        nn_model.save_model(nn_model.model_save_path + new_suffix)
 
         if new_suffix != old_suffix:
-            _delete_model(model_path + old_suffix)
+            nn_model.delete_model(nn_model.model_save_path + old_suffix)
     else:
-        _save_model(nn_model, model_path)
+        nn_model.save_model(nn_model.model_save_path)
 
     return best_perplexities
 
@@ -52,7 +47,8 @@ def _calc_and_save_train_metrics(nn_model, train_subset, avg_loss):
     train_metrics = dict()
     train_metrics['train_perplexity'] = calculate_model_mean_perplexity(nn_model, train_subset)
     train_metrics['train_loss'] = avg_loss
-    save_metrics(train_metrics)
+
+    save_metrics(train_metrics, nn_model.model_name)
 
     _logger.info('Current train perplexity: %s' % train_metrics['train_perplexity'])
     return train_metrics
@@ -62,9 +58,10 @@ def _calc_and_save_val_metrics(nn_model,
                                context_sensitive_val_subset,
                                context_free_val,
                                prediction_mode=PREDICTION_MODE_FOR_TESTS):
+
     val_metrics = calculate_and_log_val_metrics(nn_model, context_sensitive_val_subset, context_free_val,
                                                 prediction_mode)
-    save_metrics(val_metrics)
+    save_metrics(val_metrics, nn_model.model_name)
 
     return val_metrics
 
@@ -73,10 +70,8 @@ def _save_val_results(nn_model,
                       x_context_free_val,
                       x_context_sensitive_val_subset,
                       val_metrics,
-                      train_info,
-                      suffix='',
-                      prediction_mode=PREDICTION_MODE_FOR_TESTS):
-    start_time, batch_id, batches_num = train_info
+                      train_stats,
+                      suffix=''):
 
     context_free_perplexity = val_metrics['context_free_perplexity'] if val_metrics else None
     context_sensitive_perplexity = val_metrics['context_sensitive_perplexity'] if val_metrics else None
@@ -84,26 +79,23 @@ def _save_val_results(nn_model,
     save_test_results(
         x_context_free_val,
         nn_model,
-        start_time,
-        batch_id,
-        batches_num,
+        train_stats.start_time,
+        train_stats.cur_batch_id,
+        train_stats.batches_num,
         suffix='_context_free' + suffix,
-        cur_perplexity=context_free_perplexity,
-        prediction_mode=prediction_mode)
+        cur_perplexity=context_free_perplexity)
 
     save_test_results(
         x_context_sensitive_val_subset,
         nn_model,
-        start_time,
-        batch_id,
-        batches_num,
+        train_stats.start_time,
+        train_stats.cur_batch_id,
+        train_stats.batches_num,
         suffix='_context_sensitive' + suffix,
-        cur_perplexity=context_sensitive_perplexity,
-        prediction_mode=prediction_mode)
+        cur_perplexity=context_sensitive_perplexity)
 
 
-def _log_sample_answers(x_test, nn_model, mode, is_reverse_model):
-    _logger.info('Model: {}'.format(get_model_full_path(is_reverse_model)))
+def _log_sample_answers(x_test, nn_model, mode):
     _logger.info('Start predicting responses of length {out_len} for {n_samples} samples with mode {mode}'.format(
         out_len=MAX_PREDICTIONS_LENGTH, n_samples=x_test.shape[0], mode=mode))
 
@@ -116,15 +108,73 @@ def _log_sample_answers(x_test, nn_model, mode, is_reverse_model):
         for j, response in enumerate(responses[i]):
             laconic_logger.info('%-35s\t --#=%02d--> \t%s' % (question, j + 1, response))
 
+    laconic_logger.info('')  # for better readability
 
-def train_model(nn_model, is_reverse_model=False):
-    """
-    Main function fo training. Refactoring anticipated.
-    """
-    validation_prediction_mode = PREDICTION_MODES.sampling if is_reverse_model else PREDICTION_MODE_FOR_TESTS
 
+def _log_train_info_for_one_batch(train_stats):
+    total_time = (time.time() - train_stats.start_time) / 3600  # in hours
+    total_train_time = train_stats.total_training_time / 3600  # in hours
+    shifted_batch_id = train_stats.cur_batch_id + 1
+
+    progress = float(shifted_batch_id) / train_stats.batches_num
+    avr_time_per_batch = total_time / shifted_batch_id
+    expected_time_per_epoch = avr_time_per_batch * train_stats.batches_num
+    total_training_time_in_percent = total_train_time / total_time
+
+    # use print here for better readability
+    _logger.info('batch {batch_id} / {batches_num} ({progress:.1%}) \t'
+                 'loss: {loss:.2f} \t '
+                 'time: epoch {epoch_time:.1f} h | total {total_time:.1f} h | '
+                 'train {train_time:.1f} h ({train_time_percent:.1%})'
+                 .format(
+                    batch_id=shifted_batch_id,
+                    batches_num=train_stats.batches_num,
+                    progress=progress,
+                    loss=train_stats.cur_loss,
+                    epoch_time=expected_time_per_epoch,
+                    total_time=total_time,
+                    train_time=total_train_time,
+                    train_time_percent=total_training_time_in_percent
+                  ))
+
+
+def _analyse_model_performance_and_dump_results(nn_model, datasets, train_stats):
+    cur_best_val_perplexities = train_stats.best_val_perplexities
+    cur_val_metrics = train_stats.cur_val_metrics
+
+    _log_train_info_for_one_batch(train_stats)
+
+    if train_stats.cur_batch_id % SCREEN_LOG_FREQUENCY_PER_BATCHES == 0:
+        questions_for_sampling = datasets.context_free_val.x[:SCREEN_LOG_NUM_TEST_LINES]
+        _log_sample_answers(questions_for_sampling, nn_model, PREDICTION_MODE_FOR_TESTS)
+
+    if train_stats.cur_batch_id % LOG_TO_TB_FREQUENCY_PER_BATCHES == 0:
+        # save metrics on train data
+        _calc_and_save_train_metrics(nn_model,
+                                     datasets.train_subset,
+                                     train_stats.cur_loss)
+
+        # save metrics on validation data
+        cur_val_metrics = _calc_and_save_val_metrics(
+            nn_model,
+            datasets.context_sensitive_val_subset,
+            datasets.context_free_val,
+            prediction_mode=PREDICTION_MODE_FOR_TESTS)
+
+    if train_stats.cur_batch_id % LOG_TO_FILE_FREQUENCY_PER_BATCHES == 0:
+        # save predictions on validation inputs
+        _save_val_results(
+            nn_model,
+            datasets.context_free_val.x,
+            datasets.context_sensitive_val_subset.x,
+            cur_val_metrics,
+            train_stats=train_stats)
+
+    return cur_best_val_perplexities, cur_val_metrics
+
+
+def _get_datasets(nn_model, is_reverse_model):
     train = load_conditioned_train_set(nn_model.token_to_index, nn_model.condition_to_index)
-
     context_free_val = load_context_free_val(nn_model.token_to_index)
 
     context_sensitive_val = load_context_sensitive_val(nn_model.token_to_index, nn_model.condition_to_index)
@@ -140,83 +190,65 @@ def train_model(nn_model, is_reverse_model=False):
     # Context-sensitive val subset of same size as a context-free val for metrics calculation
     context_sensitive_val_subset = generate_subset(context_sensitive_val, VAL_SUBSET_SIZE)
 
+    datasets_collection = DatasetsCollection(
+        train=train,
+        train_subset=train_subset,
+        context_free_val=context_free_val,
+        context_sensitive_val=context_sensitive_val,
+        context_sensitive_val_subset=context_sensitive_val_subset
+    )
+
+    return datasets_collection
+
+
+def _get_decayed_avg_loss(avg_loss, new_loss, avg_loss_decay=AVG_LOSS_DECAY):
+    return avg_loss_decay * avg_loss + (1 - avg_loss_decay) * new_loss
+
+
+def train_model(nn_model):
+    _logger.info('\nDefault model save path:\n{}\n'.format(nn_model.model_save_path))
+
+    datasets_collection = _get_datasets(nn_model, nn_model.is_reverse_model)
     _logger.info('Finished preprocessing! Start training')
 
     batch_id = 0
-    avg_loss = 0
-    total_training_time = 0
     best_val_perplexities = (float('inf'), float('inf'))
-    batches_num = (train.x.shape[0] - 1) / BATCH_SIZE + 1
-    start_time = time.time()
     cur_val_metrics = None
 
-    try:
-        for epoches_counter in xrange(1, EPOCHES_NUM + 1):
-            _logger.info('Starting epoch #%d; time = %0.2f s(training of it = %0.2f s)' %
-                         (epoches_counter, time.time() - start_time, total_training_time))
+    batches_num = (datasets_collection.train.x.shape[0] + BATCH_SIZE - 1) // BATCH_SIZE
+    # The adding (BATCH_SIZE - 1) should be used here to count the last batch
+    # that may be smaller than BATCH_SIZE
 
-            for train_batch in get_training_batch(
-                [train.x, train.y, train.condition_ids], BATCH_SIZE, random_permute=SHUFFLE_TRAINING_BATCHES):
-                x_train_batch, y_train_batch, condition_ids_train_batch = train_batch
+    cur_loss = 0
+    total_training_time = 0
+    start_time = time.time()
 
-                batch_id += 1
-                prev_time = time.time()
-                loss = nn_model.train(x_train_batch, y_train_batch, condition_ids_train_batch)
+    for epoch_id in xrange(EPOCHS_NUM):
+        _logger.info('Starting epoch #{}'.format(epoch_id))
 
-                cur_time = time.time()
-                total_training_time += cur_time - prev_time
-                total_time = cur_time - start_time
-                avg_loss = LOG_LOSS_DECAY * avg_loss + (1 - LOG_LOSS_DECAY) * loss if batch_id > 1 else loss
+        for train_batch in get_training_batch(datasets_collection.train,
+                                              BATCH_SIZE,
+                                              random_permute=SHUFFLE_TRAINING_BATCHES):
+            train_stats = TrainStats(
+                cur_batch_id=batch_id,
+                batches_num=batches_num,
+                start_time=start_time,
+                total_training_time=total_training_time,
+                cur_loss=cur_loss,
+                best_val_perplexities=best_val_perplexities,
+                cur_val_metrics=cur_val_metrics
+            )
 
-                progress = 100 * float(batch_id) / batches_num
-                avr_time_per_sample = total_time / batch_id
-                expected_time_per_epoch = avr_time_per_sample * batches_num
+            best_val_perplexities, cur_val_metrics = \
+                _analyse_model_performance_and_dump_results(nn_model, datasets_collection, train_stats)
 
-                # use print here for better readability
-                _logger.info('batch %s / %s (%d%%) \t'
-                             'loss: %.2f \t '
-                             'time: epoch %.1f h | '
-                             'total %0.1f h | '
-                             'train %0.1f h (%.1f%%)' %
-                             (batch_id, batches_num, progress, avg_loss, expected_time_per_epoch / 3600,
-                              total_time / 3600, total_training_time / 3600, 100 * total_training_time / total_time))
+            best_val_perplexities = \
+                _update_saved_nn_model(nn_model, cur_val_metrics, best_val_perplexities, train_stats)
 
-                if batch_id % SCREEN_LOG_FREQUENCY_PER_BATCHES == 0:
-                    _log_sample_answers(context_free_val.x[:SCREEN_LOG_NUM_TEST_LINES], nn_model,
-                                        validation_prediction_mode, is_reverse_model)
+            prev_time = time.time()
 
-                if batch_id % LOG_FREQUENCY_PER_BATCHES == 0:
-                    _calc_and_save_train_metrics(nn_model, train_subset, avg_loss)
+            loss = nn_model.train(*train_batch)
+            cur_loss = _get_decayed_avg_loss(cur_loss, loss) if batch_id else loss
 
-                    val_metrics = _calc_and_save_val_metrics(
-                        nn_model,
-                        context_sensitive_val_subset,
-                        context_free_val,
-                        prediction_mode=validation_prediction_mode)
-                    _save_val_results(
-                        nn_model,
-                        context_free_val.x,
-                        context_sensitive_val_subset.x,
-                        val_metrics,
-                        train_info=(start_time, batch_id, batches_num),
-                        prediction_mode=validation_prediction_mode)
-                    cur_val_metrics = val_metrics
-
-                    best_val_perplexities = \
-                        _update_saved_nn_model(nn_model,
-                                               (val_metrics['context_free_perplexity'],
-                                                val_metrics['context_sensitive_perplexity']),
-                                               best_val_perplexities,
-                                               is_reverse_model=is_reverse_model)
-
-    except (KeyboardInterrupt, SystemExit):
-        _logger.info('Training cycle is stopped manually')
-        _save_model(nn_model, get_model_full_path(is_reverse_model) + '_final')
-        _save_val_results(
-            nn_model,
-            context_free_val.x,
-            context_sensitive_val_subset.x,
-            cur_val_metrics,
-            train_info=(start_time, batch_id, batches_num),
-            suffix='_final',
-            prediction_mode=validation_prediction_mode)
+            total_training_time += time.time() - prev_time
+            batch_id += 1

--- a/cakechat/utils/data_types.py
+++ b/cakechat/utils/data_types.py
@@ -1,0 +1,22 @@
+from collections import namedtuple
+
+
+Dataset = namedtuple('Dataset', ['x', 'y', 'condition_ids'])
+
+DatasetsCollection = namedtuple('DatasetsCollection', [
+    'train',
+    'train_subset',
+    'context_free_val',
+    'context_sensitive_val',
+    'context_sensitive_val_subset'
+])
+
+TrainStats = namedtuple('TrainStats', [
+    'cur_batch_id',
+    'batches_num',
+    'start_time',
+    'total_training_time',
+    'cur_loss',
+    'best_val_perplexities',
+    'cur_val_metrics'
+])

--- a/cakechat/utils/files_utils.py
+++ b/cakechat/utils/files_utils.py
@@ -1,6 +1,7 @@
 import os
 import codecs
 from abc import abstractmethod, ABCMeta
+
 from six.moves import cPickle as pickle
 
 from cakechat.utils.logger import get_logger
@@ -60,7 +61,7 @@ def ensure_dir(dir_name):
         os.makedirs(dir_name)
 
 
-def serialize(filename, data, protocol=pickle.HIGHEST_PROTOCOL):
+def serialize(filename, data, protocol=2):
     ensure_dir(os.path.dirname(filename))
     with open(filename, 'wb') as f:
         pickle.dump(data, f, protocol)
@@ -95,3 +96,7 @@ def get_persisted(factory, persisted_file_name, **kwargs):
 
 def is_non_empty_file(file_path):
     return os.path.isfile(file_path) and os.stat(file_path).st_size != 0
+
+
+class FileNotFoundException(Exception):
+    pass

--- a/cakechat/utils/logger.py
+++ b/cakechat/utils/logger.py
@@ -37,7 +37,7 @@ def get_tools_logger(name):
 
 
 def _get_laconic_logger():
-    return logging.getLogger('laconic_logger')
+    return get_tools_logger('laconic_logger')
 
 
 class WithLogger(object):

--- a/cakechat/utils/offense_detector/config.py
+++ b/cakechat/utils/offense_detector/config.py
@@ -5,3 +5,4 @@ import cakechat.utils.offense_detector
 
 OFFENSIVE_PHRASES_PATH = pkg_resources.resource_filename(cakechat.utils.offense_detector.__name__,
                                                          os.path.join('data', 'offensive_phrases.csv'))
+

--- a/cakechat/utils/offense_detector/detector.py
+++ b/cakechat/utils/offense_detector/detector.py
@@ -2,7 +2,6 @@ import nltk
 from six import string_types
 from six.moves import xrange
 
-
 from cakechat.utils.files_utils import load_file
 from cakechat.utils.text_processing import get_tokens_sequence
 from cakechat.utils.data_structures import flatten

--- a/cakechat/utils/s3/resolver.py
+++ b/cakechat/utils/s3/resolver.py
@@ -23,7 +23,6 @@ class S3FileResolver(AbstractFileResolver, WithLogger):
     def init_resolver(**kwargs):
         """
         Method helping to set once some parameters like bucket_name and remote_dir
-
         :param kwargs:
         :return: partially initialized class object
         """

--- a/cakechat/utils/tee_file.py
+++ b/cakechat/utils/tee_file.py
@@ -1,8 +1,7 @@
 import os
 import tempfile
 
-from six.moves import xrange
-from six.moves import cPickle as pickle
+from six.moves import cPickle as pickle, xrange
 
 # Pickle on HIGHEST_PROTOCOL breaks on Python 3.6.5
 _PICKLE_PROTOCOL = 2

--- a/cakechat/utils/telegram_bot_client.py
+++ b/cakechat/utils/telegram_bot_client.py
@@ -1,8 +1,8 @@
 from abc import ABCMeta, abstractmethod
-from six import iteritems
 
 import telepot
 import telepot.loop
+from six import iteritems
 
 from cakechat.utils.logger import WithLogger
 

--- a/cakechat/utils/text_processing/corpus_iterator.py
+++ b/cakechat/utils/text_processing/corpus_iterator.py
@@ -44,7 +44,7 @@ class JsonTextLinesIterator(object):
             try:
                 yield json.loads(line.strip())
             except ValueError:
-                _logger.warn('Skipped invalid json object: "%s"' % line.strip())
+                _logger.warning('Skipped invalid json object: "%s"' % line.strip())
                 continue
 
     def __copy__(self):

--- a/cakechat/utils/text_processing/utils.py
+++ b/cakechat/utils/text_processing/utils.py
@@ -1,6 +1,7 @@
 import os
-import codecs
 import json
+import codecs
+
 from six import iteritems
 
 from cakechat.config import PROCESSED_CORPUS_DIR, TOKEN_INDEX_DIR, CONDITION_IDS_INDEX_DIR

--- a/cakechat/utils/w2v/model.py
+++ b/cakechat/utils/w2v/model.py
@@ -3,11 +3,11 @@ import os
 
 from gensim.models import Word2Vec
 
+from cakechat.config import WORD_EMBEDDING_DIMENSION, W2V_WINDOW_SIZE, MIN_WORD_FREQ, USE_SKIP_GRAM
 from cakechat.utils.files_utils import DummyFileResolver, ensure_dir
 from cakechat.utils.logger import get_logger
 from cakechat.utils.tee_file import file_buffered_tee
 from cakechat.utils.w2v.utils import get_w2v_params_str, get_w2v_model_path
-from cakechat.config import WORD_EMBEDDING_DIMENSION, W2V_WINDOW_SIZE, MIN_WORD_FREQ, USE_SKIP_GRAM
 
 _WORKERS_NUM = multiprocessing.cpu_count()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-flask==0.12.2
-numpy==1.13.3
+flask==1.0.2
+numpy==1.14.4
+pandas==0.23.0
 Theano==0.9.0
 https://github.com/Lasagne/Lasagne/archive/master.zip
 unicodecsv==0.14.1
@@ -8,6 +9,7 @@ nltk==3.2.5
 scipy==0.19.1
 scikit-learn==0.19.1
 tensorboard-logger==0.0.4
-telepot==12.4
+telepot==12.5
 gensim==1.0.1
 six==1.11.0
+cachetools==2.1.0

--- a/tools/generate_predictions.py
+++ b/tools/generate_predictions.py
@@ -9,8 +9,7 @@ from cakechat.utils.env import init_theano_env
 init_theano_env()
 
 from cakechat.dialog_model.model import get_nn_model
-from cakechat.dialog_model.model_utils import transform_contexts_to_token_ids, get_model_full_params_str, \
-    get_model_full_path, lines_to_context
+from cakechat.dialog_model.model_utils import transform_contexts_to_token_ids, lines_to_context
 from cakechat.dialog_model.quality import log_predictions, calculate_and_log_val_metrics
 from cakechat.utils.files_utils import is_non_empty_file
 from cakechat.utils.logger import get_tools_logger
@@ -18,12 +17,12 @@ from cakechat.utils.dataset_loader import get_tokenized_test_lines, load_context
     load_context_sensitive_val
 from cakechat.utils.text_processing import get_index_to_token_path, load_index_to_item, get_index_to_condition_path
 from cakechat.config import BASE_CORPUS_NAME, QUESTIONS_CORPUS_NAME, INPUT_SEQUENCE_LENGTH, INPUT_CONTEXT_SIZE, \
-    PREDICTION_MODES, PREDICTION_MODE_FOR_TESTS, LOG_CANDIDATES_NUM, DATA_DIR
+    PREDICTION_MODES, DATA_DIR, DEFAULT_TEMPERATURE, PREDICTION_MODE_FOR_TESTS
 
 _logger = get_tools_logger(__file__)
 
 
-def _save_test_results(test_dataset, predictions_filename, nn_model, prediction_mode, **kwargs):
+def _save_test_results(test_dataset, predictions_filename, nn_model, prediction_modes, **kwargs):
     test_dataset_ids = transform_contexts_to_token_ids(
         list(lines_to_context(test_dataset)), nn_model.token_to_index, INPUT_SEQUENCE_LENGTH, INPUT_CONTEXT_SIZE)
 
@@ -35,26 +34,26 @@ def _save_test_results(test_dataset, predictions_filename, nn_model, prediction_
         predictions_filename,
         test_dataset_ids,
         nn_model,
-        mode=prediction_mode,
-        candidates_num=LOG_CANDIDATES_NUM,
+        prediction_modes,
         **kwargs)
 
 
-def predict(model_path=None,
+def predict(model_path,
             tokens_index_path=None,
             conditions_index_path=None,
             default_predictions_path=None,
             reverse_model_weights=None,
             temperatures=None,
-            prediction_mode=PREDICTION_MODE_FOR_TESTS):
-    if not model_path:
-        model_path = get_model_full_path()
+            prediction_mode=None):
+
     if not tokens_index_path:
         tokens_index_path = get_index_to_token_path(BASE_CORPUS_NAME)
     if not conditions_index_path:
         conditions_index_path = get_index_to_condition_path(BASE_CORPUS_NAME)
-    if not default_predictions_path:
-        default_predictions_path = os.path.join(DATA_DIR, 'results', 'predictions_' + get_model_full_params_str())
+    if not temperatures:
+        temperatures = [DEFAULT_TEMPERATURE]
+    if not prediction_mode:
+        prediction_mode = PREDICTION_MODE_FOR_TESTS
 
     # Construct list of parameters values for all possible combinations of passed parameters
     prediction_params = [dict()]
@@ -66,6 +65,18 @@ def predict(model_path=None,
         ]
     if temperatures:
         prediction_params = [dict(params, temperature=t) for params in prediction_params for t in temperatures]
+
+    if not is_non_empty_file(tokens_index_path):
+        _logger.warning('Couldn\'t find tokens_index file:\n{}. \nExiting...'.format(tokens_index_path))
+        return
+
+    index_to_token = load_index_to_item(tokens_index_path)
+    index_to_condition = load_index_to_item(conditions_index_path)
+
+    nn_model, _ = get_nn_model(index_to_token, index_to_condition, model_init_path=model_path)
+
+    if not default_predictions_path:
+        default_predictions_path = os.path.join(DATA_DIR, 'results', 'predictions_' + nn_model.model_name)
 
     # Get path for each combination of parameters
     predictions_paths = []
@@ -80,31 +91,18 @@ def predict(model_path=None,
     else:
         predictions_paths = [default_predictions_path + '.tsv']
 
-    if not is_non_empty_file(model_path):
-        _logger.warn('Couldn\'t find model:\n"{}". \nExiting...'.format(model_path))
-        return
-
-    if not is_non_empty_file(tokens_index_path):
-        _logger.warn('Couldn\'t find tokens_index file:\n"{}". \nExiting...'.format(tokens_index_path))
-        return
-
-    _logger.info('Model for prediction:\n{}'.format(model_path))
+    _logger.info('Model for prediction:\n{}'.format(nn_model.model_load_path))
     _logger.info('Tokens index:\n{}'.format(tokens_index_path))
     _logger.info('File with questions:\n{}'.format(QUESTIONS_CORPUS_NAME))
     _logger.info('Files to dump responses:\n{}'.format('\n'.join(predictions_paths)))
     _logger.info('Prediction parameters\n{}'.format('\n'.join([str(x) for x in prediction_params])))
 
-    index_to_token = load_index_to_item(tokens_index_path)
-    index_to_condition = load_index_to_item(conditions_index_path)
-
     processed_test_set = get_tokenized_test_lines(QUESTIONS_CORPUS_NAME, set(index_to_token.values()))
     processed_test_set = list(processed_test_set)
 
-    nn_model, _ = get_nn_model(index_to_token, index_to_condition, nn_model_path=model_path)
-
     for cur_params, cur_path in zip(prediction_params, predictions_paths):
         _logger.info('Predicting with the following params: {}'.format(cur_params))
-        _save_test_results(processed_test_set, cur_path, nn_model, prediction_mode, **cur_params)
+        _save_test_results(processed_test_set, cur_path, nn_model, prediction_modes=[prediction_mode])
 
 
 def parse_args():
@@ -116,14 +114,14 @@ def parse_args():
         action='store',
         help='Prediction mode',
         choices=PREDICTION_MODES,
-        default=PREDICTION_MODE_FOR_TESTS)
+        default=None)
 
     argparser.add_argument(
         '-m',
         '--model',
         action='store',
         help='Path to the file with your model. '
-        'Be careful, model parameters are infered from config, not from the filename',
+        'Be careful, model parameters are inferred from config, not from the filename',
         default=None)
 
     argparser.add_argument(
@@ -144,7 +142,7 @@ def parse_args():
         '-o',
         '--output',
         action='store',
-        help='Path to the file to dump predictions. '
+        help='Path to the file to dump predictions.'
         'Be careful, file extension ".tsv" is appended to the filename automatically',
         default=None)
 
@@ -156,7 +154,14 @@ def parse_args():
         help='Reverse model score weight for prediction with MMI-reranking objective. Used only in *-reranking modes',
         default=None)
 
-    argparser.add_argument('-t', '--temperatures', action='append', help='temperature values', default=None, type=float)
+    argparser.add_argument(
+        '-t',
+        '--temperatures',
+        action='append',
+        help='temperature values',
+        default=None,
+        type=float)
+
     args = argparser.parse_args()
 
     # Extra params validation

--- a/tools/generate_predictions_for_condition.py
+++ b/tools/generate_predictions_for_condition.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import argparse
 import os
 import sys

--- a/tools/quality/prediction_distinctness.py
+++ b/tools/quality/prediction_distinctness.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import os
 import sys
 import argparse
@@ -14,7 +15,6 @@ from cakechat.utils.env import init_theano_env
 init_theano_env()
 
 from cakechat.dialog_model.model import get_nn_model
-from cakechat.dialog_model.model_utils import get_model_full_path
 from cakechat.dialog_model.quality import calculate_response_ngram_distinctness
 from cakechat.utils.dataset_loader import load_datasets, load_questions_set
 from cakechat.utils.text_processing import get_index_to_token_path, load_index_to_item, get_index_to_condition_path
@@ -38,9 +38,7 @@ def log_distinct_metrics(nn_model, x, condition_ids=None, samples_num=1, ngram_l
         print(result)
 
 
-def load_model(model_path=None, tokens_index_path=None, conditions_index_path=None):
-    if model_path is None:
-        model_path = get_model_full_path()
+def load_model(model_path, tokens_index_path=None, conditions_index_path=None):
     if tokens_index_path is None:
         tokens_index_path = get_index_to_token_path(BASE_CORPUS_NAME)
     if conditions_index_path is None:
@@ -48,7 +46,7 @@ def load_model(model_path=None, tokens_index_path=None, conditions_index_path=No
 
     index_to_token = load_index_to_item(tokens_index_path)
     index_to_condition = load_index_to_item(conditions_index_path)
-    nn_model, model_exists = get_nn_model(index_to_token, index_to_condition, nn_model_path=model_path)
+    nn_model, model_exists = get_nn_model(index_to_token, index_to_condition, model_path)
 
     if not model_exists:
         raise ValueError('Couldn\'t find model: "{}".'.format(model_path))

--- a/tools/quality/ranking_quality.py
+++ b/tools/quality/ranking_quality.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
+
 import os
 import sys
 
-from six.moves import xrange
 from six import iteritems
+from six.moves import xrange
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
-import sys
-import os
+
 import argparse
+import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 


### PR DESCRIPTION
## Updates:

* Model weights can be initialized from an arbitrary file in order to continue the training process (possibly with new params). In this connection:
    * there are two paths associated with a model:
        * `model_load_path` – path to a file for initializing model's weihts. This path should be passed to train script `tools/train.py` via `--init_weights` parameter. If this path is not specified, CakeChatModel will construct it based on `config.py` file and will try to initialize its weights from this file.
        * `model_save_path` – path to a file for saving model's weights. This path is constructed by CakeChatModel.
    * NN_MODEL_PREFIX – model's name always includes prefix, which can be general ('cakechat' for example), or specific for the given experiment.

* Trained models are accessed via `get_trained_model()` and cached thanks to `@cached` decorator

* Separate module for data_types – cakechat/utils/data_types.py

* Following entities are incorporated into CakeChatModel:
    * `is_reverse_model` flag
    * `params_str` – string with main model parameters
    * `save_model()` and `delete_model()` functions

* `log_predictions()` can simultaneously generate predictions for different PREDICTION_MODES, not just for one

* All datasets (train, train_subset, context_free_val, context_sensitive_val, context_sensitive_val_subset) are accessed via `get_datasets()` and passed via a namedTuple – `DatasetsCollection`

* All statistics data about train process is collected and passed via a namedTuple `TrainStats`

* Logging logic is implemented in a dedicated function `_log_train_info_for_one_batch()`

* Analytics logic (metrics calculation) is implemented in a dedicated function `_analyse_model_performance()`

* Constant `MAX_VAL_LINES_NUM` defines max lines number of validation set to be used for metrics calculation – useful for testing and debugging purposes.

* Documentation is updated for various functions

* Some typos are fixed
