### PR TITLE
Save and load weights separately for each model's param

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,16 @@ Then we marked out each utterance with our emotions classifier that predicts one
 To mark-up your own corpus with emotions you can use, for example, [DeepMoji tool](https://github.com/bfelbo/DeepMoji)
 or any other emotions classifier that you have.
 
+#### Initalizing model weights from file
+For some tools (for example [`tools/train.py`](tools/train.py)) you can specify the path to model's initialization weights via `--init_weights` argument.
+
+The weights may come from a trained CakeChat model or from a model with a different architecture.
+In the latter case some parameters of Cakechat model may be left without initialisation:
+a parameter will be initialized with a saved value if the parameter's name and shape are
+identical to the saved parameter, otherwise the parameter will keep its default initialization weights.
+
+See `load_weights` function for the details.
+
 ### Training your own model
 
 1. Put your training text corpus to [`data/corpora_processed/`](data/corpora_processed/).

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ or any other emotions classifier that you have.
 For some tools (for example [`tools/train.py`](tools/train.py)) you can specify the path to model's initialization weights via `--init_weights` argument.
 
 The weights may come from a trained CakeChat model or from a model with a different architecture.
-In the latter case some parameters of Cakechat model may be left without initialisation:
+In the latter case some parameters of Cakechat model may be left without initialization:
 a parameter will be initialized with a saved value if the parameter's name and shape are
 identical to the saved parameter, otherwise the parameter will keep its default initialization weights.
 

--- a/cakechat/config.py
+++ b/cakechat/config.py
@@ -68,7 +68,7 @@ GRAD_CLIP = 5.0  # Gradient clipping passed into theano.gradient.grad_clip()
 LEARNING_RATE = 1.0  # Learning rate for the chosen optimizer (currently using Adadelta, see model.py)
 
 # model params
-NN_MODEL_PREFIX = 'cakechat'  # Specify prefix to be prepended to model's name
+NN_MODEL_PREFIX = 'cakechat_v1.3'  # Specify prefix to be prepended to model's name
 
 # predictions params
 MAX_PREDICTIONS_LENGTH = 40  # Max. number of tokens which can be generated on the prediction step

--- a/cakechat/dialog_model/model.py
+++ b/cakechat/dialog_model/model.py
@@ -622,7 +622,7 @@ class CakeChatModel(object):
         return self._is_reverse_model
 
     def load_weights(self):
-        laconic_logger.info('\nLoading saved weights from file:\n{}\n'.format(self.model_load_path))
+        _logger.info('\nLoading saved weights from file:\n{}\n'.format(self.model_load_path))
         saved_var_name_to_var = OrderedDict(np.load(self.model_load_path))
 
         var_name_to_var = OrderedDict([(v.name, v) for v in get_all_params(self._net['dist'])])


### PR DESCRIPTION
Two functions updated:
* `save_model` preserves parameters' names while saving their values to a dump
* `load_weights` restores saved weight separately for each model's parameter

Thus you can initialize all or some of your model's parameters with weights that could come from a model with different architecture. Your model's parameter will be initialized with a saved value if the parameter's name and shape are the same as for the saved parameter. Otherwise it will keep its default initialization weights.