### PR TITLE
Updated 'requests' dependency to get rid of security alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pandas==0.23.0
 Theano==0.9.0
 https://github.com/Lasagne/Lasagne/archive/master.zip
 unicodecsv==0.14.1
-requests==2.18.4
+requests==2.21.0
 nltk==3.2.5
 scipy==0.19.1
 scikit-learn==0.19.1


### PR DESCRIPTION
Got rid of security alert about vulnerable requests version (should be updated to requests>=2.20.0)